### PR TITLE
Renaming multiple items

### DIFF
--- a/finsy/__init__.py
+++ b/finsy/__init__.py
@@ -49,6 +49,7 @@ from .p4entity import (
     P4TableMatch,
 )
 from .p4schema import P4ConfigAction, P4CounterUnit, P4Schema
+from .ports import SwitchPort, SwitchPortList
 from .switch import Switch, SwitchEvent, SwitchOptions
 
 __all__ = [
@@ -83,6 +84,8 @@ __all__ = [
     "Switch",
     "SwitchEvent",
     "SwitchOptions",
+    "SwitchPort",
+    "SwitchPortList",
     "gNMIClient",
     "gNMIPath",
     "gNMISubscription",

--- a/finsy/__init__.py
+++ b/finsy/__init__.py
@@ -26,7 +26,7 @@ from .gnmiclient import gNMIClient, gNMISubscription, gNMIUpdate
 from .gnmipath import gNMIPath
 from .grpcutil import GRPCStatusCode
 from .log import LoggerAdapter
-from .p4client import P4Client, P4ClientError
+from .p4client import P4Client, P4ClientError, P4Error
 from .p4entity import (
     P4ActionProfileGroup,
     P4ActionProfileMember,
@@ -67,6 +67,7 @@ __all__ = [
     "P4DigestList",
     "P4DigestListAck",
     "P4DirectCounterEntry",
+    "P4Error",
     "P4IndirectAction",
     "P4MeterConfig",
     "P4MeterCounterData",

--- a/finsy/gnmiclient.py
+++ b/finsy/gnmiclient.py
@@ -52,10 +52,6 @@ class gNMIClientError(Exception):
     def message(self):
         return self._message
 
-    @property
-    def is_unimplemented(self):
-        return self.code == GRPCStatusCode.UNIMPLEMENTED
-
     def __str__(self) -> str:
         return f"gNMIClientError(code={self.code!r}, message={self.message!r})"
 

--- a/finsy/p4arbitrator.py
+++ b/finsy/p4arbitrator.py
@@ -189,7 +189,7 @@ class Arbitrator:
             response = await switch._p4client.receive()
 
         except P4ClientError as ex:
-            if ex.status.is_election_id_used:
+            if ex.is_election_id_used:
                 return None
             raise
 

--- a/finsy/p4arbitrator.py
+++ b/finsy/p4arbitrator.py
@@ -18,7 +18,7 @@ import finsy.switch as _sw  # break circular import
 from finsy import pbuf
 from finsy.grpcutil import GRPCStatusCode
 from finsy.log import LOGGER
-from finsy.p4client import P4ClientError, P4Status
+from finsy.p4client import P4ClientError, P4RpcStatus
 from finsy.proto import U128, p4r
 
 _NOT_ASSIGNED = -1
@@ -65,14 +65,14 @@ class Arbitrator:
             self.election_id -= 1
 
         response = await self._arbitration_request(switch)
-        status = P4Status.from_status(response.status)
+        status = P4RpcStatus.from_status(response.status)
         primary_id = U128.decode(response.election_id)
 
         while status.code == GRPCStatusCode.NOT_FOUND:
             self.election_id = primary_id
 
             response = await self._arbitration_request(switch)
-            status = P4Status.from_status(response.status)
+            status = P4RpcStatus.from_status(response.status)
             primary_id = U128.decode(response.election_id)
 
         assert status.code in (GRPCStatusCode.OK, GRPCStatusCode.ALREADY_EXISTS)
@@ -84,7 +84,7 @@ class Arbitrator:
     async def update(self, switch: "_sw.Switch", msg: p4r.MasterArbitrationUpdate):
         "Called with subsequent arbitration update responses."
 
-        status_code = P4Status.from_status(msg.status).code
+        status_code = P4RpcStatus.from_status(msg.status).code
         new_primary_id = U128.decode(msg.election_id)
 
         if new_primary_id >= self.primary_id:

--- a/finsy/p4client.py
+++ b/finsy/p4client.py
@@ -49,6 +49,8 @@ _NO_PIPELINE_CONFIG = re.compile(
 
 @dataclass
 class P4SubError:
+    "P4Runtime Error message used to report a single P4-entity error."
+
     canonical_code: GRPCStatusCode
     message: str
     space: str
@@ -140,7 +142,7 @@ class P4Status:
 
 
 class P4ClientError(Exception):
-    "Wrap grpc.RpcError."
+    "Wrap `grpc.RpcError`."
 
     _operation: str
     _status: P4Status
@@ -187,10 +189,6 @@ class P4ClientError(Exception):
     def details(self) -> dict[int, P4SubError]:
         return self._status.details
 
-    @property
-    def is_unimplemented(self) -> bool:
-        return self.code == GRPCStatusCode.UNIMPLEMENTED
-
     def _attach_details(self, msg: pbuf.PBMessage):
         "Attach the subvalue(s) from the message that caused the error."
         if isinstance(msg, p4r.WriteRequest):
@@ -198,6 +196,7 @@ class P4ClientError(Exception):
                 value.subvalue = msg.updates[key]
 
     def __str__(self) -> str:
+        "Return string representation of P4ClientError object."
         if self.details:
 
             def _indent(value: P4SubError):

--- a/finsy/p4client.py
+++ b/finsy/p4client.py
@@ -48,7 +48,7 @@ _NO_PIPELINE_CONFIG = re.compile(
 
 
 @dataclass
-class P4SubError:
+class P4Error:
     "P4Runtime Error message used to report a single P4-entity error."
 
     canonical_code: GRPCStatusCode
@@ -64,7 +64,7 @@ class P4RpcStatus:
 
     code: GRPCStatusCode
     message: str
-    details: dict[int, P4SubError]
+    details: dict[int, P4Error]
 
     @staticmethod
     def from_rpc_error(error: grpc.RpcError) -> "P4RpcStatus":
@@ -99,13 +99,13 @@ class P4RpcStatus:
         )
 
     @staticmethod
-    def _parse_error(details: Sequence[pbuf.PBAny]) -> dict[int, P4SubError]:
-        result: dict[int, P4SubError] = {}
+    def _parse_error(details: Sequence[pbuf.PBAny]) -> dict[int, P4Error]:
+        result: dict[int, P4Error] = {}
 
         for i in range(len(details)):
             err = pbuf.from_any(details[i], p4r.Error)
             if err.canonical_code != rpc_code.OK:
-                result[i] = P4SubError(
+                result[i] = P4Error(
                     GRPCStatusCode(err.canonical_code),
                     err.message,
                     err.space,
@@ -151,7 +151,7 @@ class P4ClientError(Exception):
         return self._status.message
 
     @property
-    def details(self) -> dict[int, P4SubError]:
+    def details(self) -> dict[int, P4Error]:
         return self._status.details
 
     @property
@@ -191,7 +191,7 @@ class P4ClientError(Exception):
         "Return string representation of P4ClientError object."
         if self.details:
 
-            def _indent(value: P4SubError):
+            def _indent(value: P4Error):
                 s = repr(value).replace("\n}\n)", "\n})")  # tidy multiline repr
                 return s.replace("\n", "\n" + " " * 6)
 

--- a/finsy/p4client.py
+++ b/finsy/p4client.py
@@ -170,10 +170,6 @@ class P4ClientError(Exception):
         LOGGER.debug("%s failed: %s", operation, self)
 
     @property
-    def operation(self) -> str:
-        return self._operation
-
-    @property
     def status(self) -> P4Status:
         return self._status
 
@@ -212,12 +208,12 @@ class P4ClientError(Exception):
 
         if self.code == self._outer_code and self.message == self._outer_message:
             return (
-                f"operation={self.operation} code={self.code!r} "
+                f"operation={self._operation} code={self.code!r} "
                 f"message={self.message!r} {details}"
             )
         return (
             f"code={self.code!r} message={self.message!r} "
-            f"details={self.details!r} operation={self.operation} "
+            f"details={self.details!r} operation={self._operation} "
             f"_outer_message={self._outer_message!r} _outer_code={self._outer_code!r}"
         )
 

--- a/finsy/p4client.py
+++ b/finsy/p4client.py
@@ -86,7 +86,7 @@ class P4Status:
         )
 
     @property
-    def is_no_pipeline_configured(self) -> bool:
+    def is_pipeline_missing(self) -> bool:
         "Return true if error is that no pipeline config is set."
         return (
             self.code == GRPCStatusCode.FAILED_PRECONDITION

--- a/finsy/ports.py
+++ b/finsy/ports.py
@@ -39,7 +39,7 @@ class OperStatus(enum.Enum):
 
 
 @dataclass
-class Port:
+class SwitchPort:
     "Represents a switch port."
 
     id: int
@@ -52,10 +52,10 @@ class Port:
         return self.oper_status == OperStatus.UP
 
 
-class PortList:
+class SwitchPortList:
     "Represents a list of switch ports."
 
-    _ports: dict[str, Port]
+    _ports: dict[str, SwitchPort]
     _subscription: gNMISubscription | None = None
 
     def __init__(self):
@@ -89,16 +89,16 @@ class PortList:
             self._subscription = None
             self._ports = {}
 
-    async def _get_ports(self, client: gNMIClient) -> dict[str, Port]:
+    async def _get_ports(self, client: gNMIClient) -> dict[str, SwitchPort]:
         "Retrieve ID and name of each port."
-        ports: dict[str, Port] = {}
+        ports: dict[str, SwitchPort] = {}
 
         result = await client.get(_ifIndex)
         for update in result:
             path = update.path
             assert path.last == _ifIndex.last
 
-            port = Port(update.value, path["name"])
+            port = SwitchPort(update.value, path["name"])
             ports[port.name] = port
 
         return ports

--- a/finsy/switch.py
+++ b/finsy/switch.py
@@ -634,7 +634,7 @@ class Switch:
                     LOGGER.warning("Retrieved P4Info is different than expected!")
 
         except P4ClientError as ex:
-            if not ex.status.is_no_pipeline_configured:
+            if not ex.status.is_pipeline_missing:
                 raise
 
         if not has_pipeline and self.p4info.exists:
@@ -650,7 +650,7 @@ class Switch:
                 cookie = reply.config.cookie.cookie
 
         except P4ClientError as ex:
-            if not ex.status.is_no_pipeline_configured:
+            if not ex.status.is_pipeline_missing:
                 raise
 
         if cookie != self.p4info.p4cookie:

--- a/finsy/switch.py
+++ b/finsy/switch.py
@@ -904,7 +904,7 @@ class Switch:
             self._api_version = ApiVersion.parse(reply.p4runtime_api_version)
 
         except P4ClientError as ex:
-            if not ex.is_unimplemented:
+            if ex.code != GRPCStatusCode.UNIMPLEMENTED:
                 raise
             LOGGER.warning("CapabilitiesRequest is not implemented")
 
@@ -921,7 +921,7 @@ class Switch:
             self.create_task(self._ports.update(), background=True, name="_ports")
 
         except gNMIClientError as ex:
-            if not ex.is_unimplemented:
+            if ex.code != GRPCStatusCode.UNIMPLEMENTED:
                 raise
             LOGGER.warning("gNMI is not implemented")
             await self._gnmi_client.close()

--- a/finsy/switch.py
+++ b/finsy/switch.py
@@ -46,7 +46,7 @@ from finsy.log import LOGGER
 from finsy.p4arbitrator import Arbitrator
 from finsy.p4client import P4Client, P4ClientError
 from finsy.p4schema import P4ConfigAction, P4ConfigResponseType, P4Schema
-from finsy.ports import PortList
+from finsy.ports import SwitchPortList
 from finsy.proto import p4r
 
 # Maximum size of queues used for PacketIn, DigestList, etc.
@@ -148,7 +148,7 @@ class Switch:
     _packet_queues: list[tuple[Callable[[bytes], bool], asyncio.Queue[Any]]]
     _arbitrator: "Arbitrator"
     _gnmi_client: gNMIClient | None
-    _ports: PortList
+    _ports: SwitchPortList
     _is_channel_up: bool = False
     _api_version: ApiVersion = ApiVersion(1, 0, 0, "")
 
@@ -182,7 +182,7 @@ class Switch:
             options.initial_election_id, options.role_name, options.role_config
         )
         self._gnmi_client = None
-        self._ports = PortList()
+        self._ports = SwitchPortList()
         self.ee = SwitchEmitter(self)
 
     @property
@@ -253,7 +253,7 @@ class Switch:
         return self._gnmi_client
 
     @property
-    def ports(self) -> PortList:
+    def ports(self) -> SwitchPortList:
         "Switch's list of interfaces."
         return self._ports
 

--- a/finsy/switch.py
+++ b/finsy/switch.py
@@ -403,7 +403,7 @@ class Switch:
             try:
                 msg = await client.receive()
             except P4ClientError as ex:
-                if not ex.status.is_election_id_used:
+                if not ex.is_election_id_used:
                     raise
                 # Handle "election ID in use" error.
                 await self._arbitrator.handshake(self, conflict=True)
@@ -634,7 +634,7 @@ class Switch:
                     LOGGER.warning("Retrieved P4Info is different than expected!")
 
         except P4ClientError as ex:
-            if not ex.status.is_pipeline_missing:
+            if not ex.is_pipeline_missing:
                 raise
 
         if not has_pipeline and self.p4info.exists:
@@ -650,7 +650,7 @@ class Switch:
                 cookie = reply.config.cookie.cookie
 
         except P4ClientError as ex:
-            if not ex.status.is_pipeline_missing:
+            if not ex.is_pipeline_missing:
                 raise
 
         if cookie != self.p4info.p4cookie:
@@ -884,7 +884,7 @@ class Switch:
                 )
             )
         except P4ClientError as ex:
-            if strict or not ex.status.is_not_found_only:
+            if strict or not ex.is_not_found_only:
                 if warn_only:
                     LOGGER.warning(
                         "WriteRequest with `warn_only=True` failed",
@@ -893,7 +893,7 @@ class Switch:
                 else:
                     raise
 
-            assert (not strict and ex.status.is_not_found_only) or warn_only
+            assert (not strict and ex.is_not_found_only) or warn_only
 
     async def _fetch_capabilities(self):
         "Check the P4Runtime protocol version supported by the other end."

--- a/tests/test_p4client.py
+++ b/tests/test_p4client.py
@@ -1,7 +1,7 @@
 import grpc
 
 from finsy import GRPCStatusCode, P4Client, P4ClientError, pbuf
-from finsy.p4client import P4SubError
+from finsy.p4client import P4Error
 from finsy.proto import U128, p4r, rpc_status
 
 
@@ -61,7 +61,7 @@ def test_client_error():
     assert err.code == GRPCStatusCode.UNKNOWN
     assert err.message == "inner message"
     assert err.details == {
-        0: P4SubError(
+        0: P4Error(
             canonical_code=GRPCStatusCode.NOT_FOUND,
             message="sub message",
             space="",

--- a/tests/test_p4client.py
+++ b/tests/test_p4client.py
@@ -52,7 +52,7 @@ def test_client_error():
 
     ex = grpc.aio.AioRpcError(
         code=grpc.StatusCode.INTERNAL,
-        initial_metadata=[],
+        initial_metadata=grpc.aio.Metadata(),
         trailing_metadata=meta,
         details="outer message",
     )
@@ -70,4 +70,6 @@ def test_client_error():
         )
     }
 
-    assert err.status.is_not_found_only
+    assert err.is_not_found_only
+    assert not err.is_election_id_used
+    assert not err.is_pipeline_missing

--- a/tests/test_p4client.py
+++ b/tests/test_p4client.py
@@ -59,7 +59,6 @@ def test_client_error():
 
     err = P4ClientError(ex, "test_client_error")
     assert err.code == GRPCStatusCode.UNKNOWN
-    assert not err.is_unimplemented
     assert err.message == "inner message"
     assert err.details == {
         0: P4SubError(

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,11 +1,12 @@
 import asyncio
 
 import pytest
-from finsy.ports import PortList
+
+from finsy.ports import SwitchPortList
 
 
 def test_ports():
-    ports = PortList()
+    ports = SwitchPortList()
     assert len(ports) == 0
     assert list(ports) == []
 
@@ -14,7 +15,7 @@ def test_ports():
 
 
 async def test_gnmi_ports_subscribe(gnmi_client):
-    ports = PortList()
+    ports = SwitchPortList()
 
     await ports.subscribe(gnmi_client)
     for port in ports:


### PR DESCRIPTION
- Rename `is_no_pipeline_configured` property to `is_pipeline_missing`.
- Rename P4Status to P4RpcStatus.
- Move bool properties to P4ClientError from `P4RpcStatus` so P4RpcStatus can stay private.
- Rename `P4SubError` to `P4Error`.
- Rename `Port` to `SwitchPort` and `PortList` to `SwitchPortList`.