### PR TITLE
Add fail_fast option to SwitchOptions. Add run() helper function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ With Finsy, you can write a Python script that reads/writes P4Runtime entities f
 Here is a complete example that retrieves the P4Info from a switch:
 
 ```python
-import asyncio
 import finsy as fy
 
 async def main():
@@ -25,13 +24,12 @@ async def main():
         # Print out a description of the switch's P4Info, if one is configured.
         print(sw1.p4info)
 
-asyncio.run(main())
+fy.run(main())
 ```
 
 Here is another example that prints out all non-default table entries.
 
 ```python
-import asyncio
 import finsy as fy
 
 async def main():
@@ -40,7 +38,7 @@ async def main():
         async for entry in sw1.read(fy.P4TableEntry()):
             print(entry)
 
-asyncio.run(main())
+fy.run(main())
 ```
 
 ## P4Runtime Controller
@@ -94,7 +92,7 @@ controller = fy.Controller([
     fy.Switch("sw3", "127.0.0.1:50003", options),
 ])
 
-asyncio.run(controller.run())
+fy.run(controller.run())
 ```
 
 Your `ready_handler` can spawn concurrent tasks with the `Switch.create_task` method. Tasks

--- a/examples/gnmi/demo1.py
+++ b/examples/gnmi/demo1.py
@@ -1,9 +1,6 @@
-import asyncio
-import logging
+import finsy as fy
 
-from finsy import GNMIClient, GNMIPath
-
-_INTERFACE = GNMIPath("interfaces/interface[name=*]/state")
+_INTERFACE = fy.GNMIPath("interfaces/interface[name=*]/state")
 INTERFACE_ID = _INTERFACE / "id"
 INTERFACE_STATUS = _INTERFACE / "oper-status"
 
@@ -11,7 +8,7 @@ INTERFACE_STATUS = _INTERFACE / "oper-status"
 async def main():
     "Main program."
 
-    async with GNMIClient("127.0.0.1:50001") as client:
+    async with fy.GNMIClient("127.0.0.1:50001") as client:
         # Get list of interface names.
         ids = await client.get(INTERFACE_ID)
         names = [update.path["name"] for update in ids]
@@ -26,5 +23,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    asyncio.run(main())
+    fy.run(main())

--- a/examples/gnmi/demo2.py
+++ b/examples/gnmi/demo2.py
@@ -1,10 +1,6 @@
-import asyncio
-import logging
-import signal
+import finsy as fy
 
-from finsy import GNMIClient, GNMIPath
-
-_INTERFACE = GNMIPath("interfaces/interface[name=*]/state")
+_INTERFACE = fy.GNMIPath("interfaces/interface[name=*]/state")
 INTERFACE_ID = _INTERFACE / "id"
 INTERFACE_STATUS = _INTERFACE / "oper-status"
 
@@ -12,14 +8,7 @@ INTERFACE_STATUS = _INTERFACE / "oper-status"
 async def main():
     "Main program."
 
-    # Boilerplate to shutdown cleanly upon SIGTERM signal.
-    asyncio.get_running_loop().add_signal_handler(
-        signal.SIGTERM,
-        lambda task: task.cancel(),
-        asyncio.current_task(),
-    )
-
-    async with GNMIClient("127.0.0.1:50001") as client:
+    async with fy.GNMIClient("127.0.0.1:50001") as client:
         # Get list of interface names.
         ids = await client.get(INTERFACE_ID)
         names = [update.path["name"] for update in ids]
@@ -40,8 +29,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    try:
-        asyncio.run(main())
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
+    fy.run(main())

--- a/examples/hello/demo1.py
+++ b/examples/hello/demo1.py
@@ -5,9 +5,7 @@ P4MulticastGroupEntry. In addition, copies of all packets are sent to the
 controller as P4PacketIn messages.
 """
 
-import asyncio
 import logging
-import signal
 from pathlib import Path
 
 import finsy as fy
@@ -47,15 +45,6 @@ async def ready_handler(sw: fy.Switch):
 
 async def main():
     "Main program."
-
-    # Boilerplate to shutdown cleanly upon SIGTERM signal.
-    asyncio.get_running_loop().add_signal_handler(
-        signal.SIGTERM,
-        lambda task: task.cancel(),
-        asyncio.current_task(),
-    )
-
-    # Shared settings for all P4Runtime switches.
     options = fy.SwitchOptions(
         p4info=P4SRC / "hello.p4info.txt",
         p4blob=P4SRC / "hello.json",
@@ -73,8 +62,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    try:
-        asyncio.run(main())
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
+    fy.run(main())

--- a/examples/hello/demo2.py
+++ b/examples/hello/demo2.py
@@ -7,9 +7,7 @@ This demo program also demonstrates how you can organize your controller "app"
 as a Python class.
 """
 
-import asyncio
 import logging
-import signal
 from ipaddress import IPv4Address
 from pathlib import Path
 
@@ -72,14 +70,6 @@ class DemoApp:
 
 async def main():
     "Main program."
-
-    # Boilerplate to shutdown cleanly upon SIGTERM signal.
-    asyncio.get_running_loop().add_signal_handler(
-        signal.SIGTERM,
-        lambda task: task.cancel(),
-        asyncio.current_task(),
-    )
-
     app = DemoApp()
     switches = [
         fy.Switch("s1", "127.0.0.1:50001", app.options),
@@ -92,8 +82,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    try:
-        asyncio.run(main())
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
+    fy.run(main())

--- a/examples/hello/demo3.py
+++ b/examples/hello/demo3.py
@@ -8,9 +8,7 @@ connection to `sw1` using the `backup` role. The backup role is an additional
 read-only primary.
 """
 
-import asyncio
 import logging
-import signal
 from ipaddress import IPv4Address
 from pathlib import Path
 
@@ -85,14 +83,6 @@ class DemoRoleApp:
 
 async def main():
     "Main program."
-
-    # Boilerplate to shutdown cleanly upon SIGTERM signal.
-    asyncio.get_running_loop().add_signal_handler(
-        signal.SIGTERM,
-        lambda task: task.cancel(),
-        asyncio.current_task(),
-    )
-
     app = DemoRoleApp()
     switches = [
         fy.Switch("s1", "127.0.0.1:50001", app.options),
@@ -107,8 +97,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    try:
-        asyncio.run(main())
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
+    fy.run(main())

--- a/examples/int/demo/__main__.py
+++ b/examples/int/demo/__main__.py
@@ -1,11 +1,6 @@
-import asyncio
-import logging
-
 from main import main
 
+from finsy import run
+
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    try:
-        asyncio.run(main())
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
+    run(main())

--- a/examples/l2_switch/demo.py
+++ b/examples/l2_switch/demo.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import random
-import signal
 from pathlib import Path
 
 import finsy as fy
@@ -95,18 +94,9 @@ async def _log_counters(switch: fy.Switch, name: str):
 
 async def main():
     "Main program."
-
-    # Boilerplate to shutdown cleanly upon SIGTERM signal.
-    asyncio.get_running_loop().add_signal_handler(
-        signal.SIGTERM,
-        lambda task: task.cancel(),
-        asyncio.current_task(),
-    )
-
     options = fy.SwitchOptions(
         p4info=P4SRC / "l2_switch.p4info.txt",
         p4blob=P4SRC / "l2_switch.json",
-        # force_pipeline=True,
         ready_handler=_ready_handler,
     )
 
@@ -121,11 +111,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(created).03f %(levelname)s %(name)s %(message)s",
-    )
-    try:
-        asyncio.run(main())
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
+    fy.run(main())

--- a/examples/ngsdn/ngsdn/__main__.py
+++ b/examples/ngsdn/ngsdn/__main__.py
@@ -1,9 +1,6 @@
-import asyncio
+from finsy import run
 
 from .main import main
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
+    run(main())

--- a/examples/simple/demo.py
+++ b/examples/simple/demo.py
@@ -1,4 +1,3 @@
-import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -76,4 +75,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    fy.run(main())

--- a/examples/tunnel/demo1.py
+++ b/examples/tunnel/demo1.py
@@ -1,4 +1,3 @@
-import asyncio
 from pathlib import Path
 
 import finsy as fy
@@ -64,4 +63,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    fy.run(main())

--- a/examples/tunnel/demo2.py
+++ b/examples/tunnel/demo2.py
@@ -31,4 +31,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    fy.run(main())

--- a/finsy/__init__.py
+++ b/finsy/__init__.py
@@ -51,10 +51,12 @@ from .p4entity import (
 )
 from .p4schema import P4ConfigAction, P4CounterUnit, P4Schema
 from .ports import SwitchPort, SwitchPortList
+from .runner import run
 from .switch import Switch, SwitchEvent, SwitchOptions
 
 __all__ = [
     "current_controller",
+    "run",
     "Controller",
     "LoggerAdapter",
     "MACAddress",

--- a/finsy/p4entity.py
+++ b/finsy/p4entity.py
@@ -1540,8 +1540,9 @@ class P4PacketIn:
         cpm = schema.controller_packet_metadata.get("packet_in")
         if cpm is None:
             # There is no controller metadata. Warn if message has any.
-            if packet.HasField("metadata"):
-                LOGGER.warning("unexpected metadata: %r", packet.metadata)
+            pktmeta = packet.metadata
+            if pktmeta:
+                LOGGER.warning("P4PacketIn unexpected metadata: %r", pktmeta)
             return cls(packet.payload, metadata={})
 
         return cls(

--- a/finsy/runner.py
+++ b/finsy/runner.py
@@ -1,0 +1,42 @@
+"Implements the run() function."
+
+# Copyright (c) 2022-2023 Bill Fisher
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+import signal
+from typing import Any, Coroutine
+
+
+async def _finsy_main(coro: Coroutine[Any, Any, None]):
+    # Activate logging.
+    logging.basicConfig(level=logging.INFO)
+
+    # Boilerplate to shutdown cleanly upon SIGTERM signal.
+    asyncio.get_running_loop().add_signal_handler(
+        signal.SIGTERM,
+        lambda task: task.cancel(),
+        asyncio.current_task(),
+    )
+
+    await coro
+
+
+def run(coro: Coroutine[Any, Any, None]):
+    "Helper API that provides the boilerplate for `asyncio.run`."
+    try:
+        asyncio.run(_finsy_main(coro))
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        pass

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+
+import pytest
+
+import finsy as fy
+from finsy.test.p4runtime_server import P4RuntimeServer
+
+
+def test_run():
+    "Test the finsy.run() helper function."
+
+    async def _main():
+        pass
+
+    fy.run(_main())
+
+
+def test_run_failfast(unused_tcp_target, caplog):
+    "Test the finsy.run() function with a fail_fast switch."
+    caplog.set_level(logging.CRITICAL, logger="finsy")
+
+    async def _ready(sw: fy.Switch):
+        assert False
+
+    async def _main():
+        server = P4RuntimeServer(unused_tcp_target)
+        async with server.run():
+            opts = fy.SwitchOptions(ready_handler=_ready, fail_fast=True)
+            switches = [fy.Switch("sw1", unused_tcp_target, opts)]
+            await fy.Controller(switches).run()
+
+    with pytest.raises(SystemExit) as exc:
+        fy.run(_main())
+
+    assert exc.value.args[0] == 99
+    assert caplog.record_tuples == [
+        (
+            "finsy",
+            50,
+            "[] Switch task 'fy:sw1|test_run_failfast.<locals>._ready' failed",
+        )
+    ]
+
+
+def test_run_nonfailfast(unused_tcp_target, caplog):
+    "Test the finsy.run() function with a non-fail_fast switch."
+    caplog.set_level(logging.CRITICAL, logger="finsy")
+
+    async def _ready(sw: fy.Switch):
+        assert False
+
+    async def _main():
+        server = P4RuntimeServer(unused_tcp_target)
+        async with server.run():
+            opts = fy.SwitchOptions(ready_handler=_ready, fail_fast=False)
+            switches = [fy.Switch("sw1", unused_tcp_target, opts)]
+            # Set a timeout of 2 seconds.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(fy.Controller(switches).run(), 2.0)
+
+    fy.run(_main())
+
+    assert caplog.record_tuples == [
+        (
+            "finsy",
+            50,
+            "[] Switch task 'fy:sw1|test_run_nonfailfast.<locals>._ready' failed",
+        )
+    ]


### PR DESCRIPTION
- Implement the fail_fast switch option.
- Add the finsy.run() helper function.
- Arbitrator logs and ignores non-arbitration responses from the switch.
- Fix check for metadata when decoding PacketIn message.