### PR TITLE
Allow actions with 0 parameters to be encoded.

### DIFF
--- a/finsy/p4entity.py
+++ b/finsy/p4entity.py
@@ -379,8 +379,10 @@ class P4TableAction:
         except ValueError as ex:
             raise ValueError(f"{action.alias!r}: {ex}") from ex
 
-        # Check for missing action parameters.
-        if len(params) != len(aps):
+        # Check for missing action parameters. We always accept an action with
+        # no parameters.
+        param_count = len(params)
+        if param_count > 0 and param_count != len(aps):
             self._fail_missing_params(action)
 
         return p4r.Action(action_id=action.id, params=params)

--- a/tests/test_p4entity.py
+++ b/tests/test_p4entity.py
@@ -507,6 +507,43 @@ def test_table_entry_str_display():
         assert entry.action_str()
 
 
+def test_table_entry_action_id():
+    "Test P4TableEntry entity with an action_id (no parameters)."
+    entry = P4TableEntry(
+        "ipv4_lpm",
+        # 'ipv4_forward' normally requires two parameters: dstAddr and port.
+        action=P4TableAction("ipv4_forward"),
+    )
+    msg = entry.encode(_SCHEMA)
+    assert pbuf.to_dict(msg) == {
+        "table_entry": {
+            "action": {"action": {"action_id": 28792405}},
+            "table_id": 37375156,
+        },
+    }
+
+
+def test_table_update_action_id():
+    "Test P4TableEntry update with an action_id (no parameters)."
+    entry = +P4TableEntry(
+        "ipv4_lpm",
+        # 'ipv4_forward' normally requires two parameters: dstAddr and port.
+        action=P4TableAction("ipv4_forward"),
+    )
+    msg = entry.encode_update(_SCHEMA)
+
+    # Encode the message, but the P4Runtime server will not accept this.
+    assert pbuf.to_dict(msg) == {
+        "type": "INSERT",
+        "entity": {
+            "table_entry": {
+                "table_id": 37375156,
+                "action": {"action": {"action_id": 28792405}},
+            }
+        },
+    }
+
+
 def test_decode_entity1():
     "Test decode_entity function."
 


### PR DESCRIPTION
Fix #193 