### PR TITLE
Formatting helpers (match_dict, match_str, action_str) require use of P4Schema object

### DIFF
--- a/examples/ngsdn/ngsdn/console.py
+++ b/examples/ngsdn/ngsdn/console.py
@@ -76,9 +76,9 @@ async def _table(controller: fy.Controller, args: list[str]) -> None:
     if switch is None:
         raise ValueError(f"no such device: {device_name}")
 
+    p4 = switch.p4info
     async for table in switch.read(entities):
-        with switch.p4info:
-            print(table.priority, table.match_str(), "->", table.action_str())
+        print(table.priority, table.match_str(p4), "->", table.action_str(p4))
 
 
 async def _srv6_insert(controller: fy.Controller, args: list[str]) -> None:

--- a/examples/tests/testlib.py
+++ b/examples/tests/testlib.py
@@ -10,91 +10,92 @@ async def read_p4_tables(target: str, *, skip_const: bool = False) -> set[str]:
     result: set[str] = set()
 
     async with fy.Switch(f"sw@{target}", target) as sw:
-        with sw.p4info:
-            # Wildcard-read does not read default entries.
-            async for entry in sw.read(fy.P4TableEntry()):
-                assert not entry.is_default_action
+        p4 = sw.p4info
 
-                # Skip const table entries upon request.
-                if skip_const and sw.p4info.tables[entry.table_id].is_const:
-                    continue
+        # Wildcard-read does not read default entries.
+        async for entry in sw.read(fy.P4TableEntry()):
+            assert not entry.is_default_action
 
-                if entry.priority != 0:
-                    info = f"{entry.table_id} {entry.priority:#x}"
-                else:
-                    info = entry.table_id
+            # Skip const table entries upon request.
+            if skip_const and sw.p4info.tables[entry.table_id].is_const:
+                continue
 
-                match_str = entry.match_str(wildcard="*")
-                if match_str:
-                    result.add(f"{info} {match_str} {entry.action_str()}")
-                else:
-                    # Table has no match fields.
-                    result.add(f"{info} {entry.action_str()}")
+            if entry.priority != 0:
+                info = f"{entry.table_id} {entry.priority:#x}"
+            else:
+                info = entry.table_id
 
-            # Read default entries for each table.
-            for table in sw.p4info.tables:
-                # Skip const table entries upon request.
-                if skip_const and table.is_const:
-                    continue
+            match_str = entry.match_str(p4, wildcard="*")
+            if match_str:
+                result.add(f"{info} {match_str} {entry.action_str(p4)}")
+            else:
+                # Table has no match fields.
+                result.add(f"{info} {entry.action_str(p4)}")
 
-                async for entry in sw.read(
-                    fy.P4TableEntry(
-                        table_id=table.alias,
-                        is_default_action=True,
-                    )
-                ):
-                    assert entry.is_default_action
-                    assert entry.priority == 0
-                    assert entry.match_str() == ""
-                    result.add(f"{entry.table_id} {entry.action_str()}")
+        # Read default entries for each table.
+        for table in sw.p4info.tables:
+            # Skip const table entries upon request.
+            if skip_const and table.is_const:
+                continue
 
-            # Read action profiles. Ignore an INVALID_ARGUMENT error that is
-            # raised when the selector programming mode is using one shots.
-            try:
-                async for entry in sw.read(fy.P4ActionProfileGroup()):
-                    # Group syntax uses [ ]
-                    result.add(
-                        f"@{entry.action_profile_id}[{entry.group_id:#x}]"
-                        f" max_size={entry.max_size:#x} {entry.action_str()}"
-                    )
+            async for entry in sw.read(
+                fy.P4TableEntry(
+                    table_id=table.alias,
+                    is_default_action=True,
+                )
+            ):
+                assert entry.is_default_action
+                assert entry.priority == 0
+                assert entry.match_str(p4) == ""
+                result.add(f"{entry.table_id} {entry.action_str(p4)}")
 
-                async for entry in sw.read(fy.P4ActionProfileMember()):
-                    # Member syntax uses [[ ]]
-                    result.add(
-                        f"@{entry.action_profile_id}[[{entry.member_id:#x}]] {entry.action_str()}"
-                    )
-
-            except fy.P4ClientError as ex:
-                if ex.code != fy.GRPCStatusCode.INVALID_ARGUMENT:
-                    raise
-
-            # Read CloneSessionEntry's.
-            async for entry in sw.read(fy.P4CloneSessionEntry()):
-                # Include packet_length only if it is non-zero.
-                packet_length = entry.packet_length_bytes
-                if packet_length != 0:
-                    pkt_len_str = f"packet_length={packet_length} "
-                else:
-                    pkt_len_str = ""
+        # Read action profiles. Ignore an INVALID_ARGUMENT error that is
+        # raised when the selector programming mode is using one shots.
+        try:
+            async for entry in sw.read(fy.P4ActionProfileGroup()):
+                # Group syntax uses [ ]
                 result.add(
-                    f"/clone/{entry.session_id:#x} class_of_service={entry.class_of_service} {pkt_len_str}{entry.replicas_str()}"
+                    f"@{entry.action_profile_id}[{entry.group_id:#x}]"
+                    f" max_size={entry.max_size:#x} {entry.action_str(p4)}"
                 )
 
-            # Read MulticastGroupEntry's.
-            async for entry in sw.read(fy.P4MulticastGroupEntry()):
+            async for entry in sw.read(fy.P4ActionProfileMember()):
+                # Member syntax uses [[ ]]
                 result.add(
-                    f"/multicast/{entry.multicast_group_id:#x} {entry.replicas_str()}"
+                    f"@{entry.action_profile_id}[[{entry.member_id:#x}]] {entry.action_str(p4)}"
                 )
 
-            # Read all DigestEntry's (wildcard reads are not supported).
-            digest_entries = [
-                fy.P4DigestEntry(digest.alias) for digest in sw.p4info.digests
-            ]
-            if digest_entries:
-                async for entry in sw.read(digest_entries):
-                    result.add(
-                        f"/digest/{entry.digest_id} max_list_size={entry.max_list_size} max_timeout_ns={entry.max_timeout_ns} ack_timeout_ns={entry.ack_timeout_ns}"
-                    )
+        except fy.P4ClientError as ex:
+            if ex.code != fy.GRPCStatusCode.INVALID_ARGUMENT:
+                raise
+
+        # Read CloneSessionEntry's.
+        async for entry in sw.read(fy.P4CloneSessionEntry()):
+            # Include packet_length only if it is non-zero.
+            packet_length = entry.packet_length_bytes
+            if packet_length != 0:
+                pkt_len_str = f"packet_length={packet_length} "
+            else:
+                pkt_len_str = ""
+            result.add(
+                f"/clone/{entry.session_id:#x} class_of_service={entry.class_of_service} {pkt_len_str}{entry.replicas_str()}"
+            )
+
+        # Read MulticastGroupEntry's.
+        async for entry in sw.read(fy.P4MulticastGroupEntry()):
+            result.add(
+                f"/multicast/{entry.multicast_group_id:#x} {entry.replicas_str()}"
+            )
+
+        # Read all DigestEntry's (wildcard reads are not supported).
+        digest_entries = [
+            fy.P4DigestEntry(digest.alias) for digest in sw.p4info.digests
+        ]
+        if digest_entries:
+            async for entry in sw.read(digest_entries):
+                result.add(
+                    f"/digest/{entry.digest_id} max_list_size={entry.max_list_size} max_timeout_ns={entry.max_timeout_ns} ack_timeout_ns={entry.ack_timeout_ns}"
+                )
 
     return result
 

--- a/finsy/p4entity.py
+++ b/finsy/p4entity.py
@@ -42,6 +42,8 @@ from finsy.p4schema import (
 )
 from finsy.proto import p4r
 
+NOACTION_STR = "NoAction()"
+
 
 class _SupportsDecodeEntity(Protocol):
     @classmethod
@@ -293,7 +295,7 @@ class P4TableMatch(dict[str, Any]):
     of the match field. The field's value should be appropriate for the type
     of match (EXACT, LPM, TERNARY, etc.)
 
-    You will construct a match the same as any dictionary.
+    Construct a match similar to a dictionary.
 
     Example:
     ```
@@ -1152,7 +1154,7 @@ class P4TableEntry(_P4Writable):
             schema = P4Schema.current()
         table = schema.tables[self.table_id]
         if self.action is None:
-            return "NoAction()"
+            return NOACTION_STR
         return self.action.format_str(table)
 
 
@@ -1392,11 +1394,12 @@ class P4ActionProfileMember(_P4Writable):
             action=action,
         )
 
-    def action_str(self) -> str:
-        "Return string representation of action."
-        if not self.action:
-            return ""
-        schema = P4Schema.current()
+    def action_str(self, schema: P4Schema | None = None) -> str:
+        "Format the action as a human-readable, canonical string."
+        if schema is None:
+            schema = P4Schema.current()
+        if self.action is None:
+            return NOACTION_STR
         return self.action.format_str(schema)
 
 
@@ -1498,7 +1501,7 @@ class P4ActionProfileGroup(_P4Writable):
             members=members,
         )
 
-    def action_str(self) -> str:
+    def action_str(self, _schema: P4Schema | None = None) -> str:
         "Return string representation of the weighted members."
         if not self.members:
             return ""

--- a/finsy/p4entity.py
+++ b/finsy/p4entity.py
@@ -1117,7 +1117,7 @@ class P4TableEntry(_P4Writable):
 
     def match_dict(
         self,
-        schema: P4Schema | None = None,
+        schema: P4Schema,
         *,
         wildcard: str | None = None,
     ) -> dict[str, str]:
@@ -1127,8 +1127,6 @@ class P4TableEntry(_P4Writable):
         `wildcard` is set, include all field names but replace unset values with
         given wildcard value (e.g. "*")
         """
-        if schema is None:
-            schema = P4Schema.current()
         table = schema.tables[self.table_id]
         if self.match is not None:
             return self.match.format_dict(table, wildcard=wildcard)
@@ -1136,22 +1134,18 @@ class P4TableEntry(_P4Writable):
 
     def match_str(
         self,
-        schema: P4Schema | None = None,
+        schema: P4Schema,
         *,
         wildcard: str | None = None,
     ) -> str:
         "Format the match fields as a human-readable, canonical string."
-        if schema is None:
-            schema = P4Schema.current()
         table = schema.tables[self.table_id]
         if self.match is not None:
             return self.match.format_str(table, wildcard=wildcard)
         return P4TableMatch().format_str(table, wildcard=wildcard)
 
-    def action_str(self, schema: P4Schema | None = None) -> str:
+    def action_str(self, schema: P4Schema) -> str:
         "Format the actions as a human-readable, canonical string."
-        if schema is None:
-            schema = P4Schema.current()
         table = schema.tables[self.table_id]
         if self.action is None:
             return NOACTION_STR
@@ -1394,10 +1388,8 @@ class P4ActionProfileMember(_P4Writable):
             action=action,
         )
 
-    def action_str(self, schema: P4Schema | None = None) -> str:
+    def action_str(self, schema: P4Schema) -> str:
         "Format the action as a human-readable, canonical string."
-        if schema is None:
-            schema = P4Schema.current()
         if self.action is None:
             return NOACTION_STR
         return self.action.format_str(schema)
@@ -1501,7 +1493,7 @@ class P4ActionProfileGroup(_P4Writable):
             members=members,
         )
 
-    def action_str(self, _schema: P4Schema | None = None) -> str:
+    def action_str(self, _schema: P4Schema) -> str:
         "Return string representation of the weighted members."
         if not self.members:
             return ""

--- a/finsy/p4schema.py
+++ b/finsy/p4schema.py
@@ -649,32 +649,10 @@ class P4Schema(_ReprMixin):
         "Collection of P4 extern instances."
         return self._p4defs.externs
 
-    @staticmethod
-    def current() -> "P4Schema":
-        "Return the current P4Schema context."
-        result = _P4SCHEMA_CTXT.get()
-        if result is None:
-            raise RuntimeError("not in P4Schema context")
-        return result
-
-    def __enter__(self) -> "P4Schema":
-        if _P4SCHEMA_CTXT.get() is not None:
-            raise RuntimeError("Do not stack P4Schema context managers")
-        _P4SCHEMA_CTXT.set(self)
-        return self
-
-    def __exit__(self, *_args: Any) -> bool | None:
-        _P4SCHEMA_CTXT.set(None)
-
     def __str__(self) -> str:
         if self._p4info is None:
             return "<P4Info: No pipeline configured>"
         return str(P4SchemaDescription(self))
-
-
-# Context var that stores the current context for convenience. Returned by
-# `P4Schema.current()`.
-_P4SCHEMA_CTXT: ContextVar[P4Schema | None] = ContextVar("_P4SCHEMA_CTXT", default=None)
 
 
 def _sort_map(value: Mapping[Any, Any]):

--- a/tests/test_p4entity.py
+++ b/tests/test_p4entity.py
@@ -530,13 +530,9 @@ def test_table_entry_str_display():
     )
     assert f"{entry}" == str(entry)
 
-    with _SCHEMA:
-        # Test schema-aware formatting.
-        assert entry.match_str() == "dstAddr=0x1"
-        assert entry.action_str() == "ipv4_forward(dstAddr=0x10203040506, port=0x1)"
-
-    with pytest.raises(RuntimeError, match="not in P4Schema context"):
-        assert entry.action_str()
+    # Test schema-aware formatting.
+    assert entry.match_str(_SCHEMA) == "dstAddr=0x1"
+    assert entry.action_str(_SCHEMA) == "ipv4_forward(dstAddr=0x10203040506, port=0x1)"
 
 
 def test_table_entry_action_id():
@@ -748,10 +744,10 @@ def test_action_profile_member_actionstr():
         member_id=2,
         action=P4TableAction("pop_vlan"),
     )
-    with schema:
-        assert entry.action_profile_id == "hashed_selector"
-        assert entry.member_id == 2
-        assert entry.action_str() == "pop_vlan()"
+
+    assert entry.action_profile_id == "hashed_selector"
+    assert entry.member_id == 2
+    assert entry.action_str(schema) == "pop_vlan()"
 
 
 def test_action_profile_group1():
@@ -804,11 +800,10 @@ def test_action_profile_group_actionstr():
         ],
     )
 
-    with schema:
-        assert entry.action_profile_id == "hashed_selector"
-        assert entry.group_id == 2
-        assert entry.max_size == 3
-        assert entry.action_str() == "(3, 2748)*0x1 4*0x2"
+    assert entry.action_profile_id == "hashed_selector"
+    assert entry.group_id == 2
+    assert entry.max_size == 3
+    assert entry.action_str(schema) == "(3, 2748)*0x1 4*0x2"
 
 
 def test_member():


### PR DESCRIPTION
Fixes #499 

- Only p4info-aware formatting is supported -- you must pass P4Schema to match_dict, match_str and action_str.
- Removed use of P4Schema as a context manager.