### PR TITLE
Remove unnecessary sleep and fix asyncio ERROR message.

### DIFF
--- a/finsy/test/gnmi_server.py
+++ b/finsy/test/gnmi_server.py
@@ -135,7 +135,6 @@ class GNMIServer(gnmi_grpc.gNMIServicer):
                             await asyncio.sleep(0.2)
                             for reply in _GNMI_SUBSCRIBE_RESPONSES_UPDATES:
                                 yield pbutil.from_text(reply, gnmi.SubscribeResponse)
-                    await asyncio.sleep(5.0)
                 case "poll":  # not supported
                     raise RuntimeError("not supported")
                 case _:


### PR DESCRIPTION
This was keeping the GNMI Subscribe task alive until the event loop was closed in CI testing.

Fixes #505 