### PR TITLE
Switch API cleanup

### DIFF
--- a/examples/ngsdn/ngsdn/route.py
+++ b/examples/ngsdn/ngsdn/route.py
@@ -114,7 +114,7 @@ class RouteManagerOneShot:
         controller = fy.Controller.current()
         links = [
             (event.local_port, controller[event.remote_switch])
-            for event in self.switch.manager["link"].links.values()
+            for event in self.switch.stash["link"].links.values()
         ]
 
         return [

--- a/finsy/switch.py
+++ b/finsy/switch.py
@@ -160,6 +160,15 @@ class Switch:
     A `Switch` is constructed with a `name`, `address` and an optional
     `SwitchOptions` configuration.
 
+    The `name` is up to the user but should uniquely identify the switch.
+
+    The `address` identifies the target endpoint of the GRPC channel. It should
+    have the format "<address>:<port>" where <address> can be a domain name,
+    IPv4 address, or IPv6 address in square brackets.
+
+    The `options` is a `SwitchOptions` object that specifies how the `Switch`
+    will behave.
+
     ```
     opts = SwitchOptions(p4info=..., p4blob=...)
     sw1 = Switch('sw1', '10.0.0.1:50000', opts)
@@ -173,6 +182,7 @@ class Switch:
     _name: str
     _address: str
     _options: SwitchOptions
+    _stash: dict[str, Any]
     _p4client: P4Client | None
     _p4schema: P4Schema
     _tasks: "SwitchTasks | None"
@@ -191,9 +201,6 @@ class Switch:
     ee: "SwitchEmitter"
     "Event emitter."
 
-    manager: Any = None
-    "Available to attach per-switch manager(s)."
-
     def __init__(
         self,
         name: str,
@@ -206,6 +213,7 @@ class Switch:
         self._name = name
         self._address = address
         self._options = options
+        self._stash = {}
         self._p4client = None
         self._p4schema = P4Schema(options.p4info, options.p4blob)
         self._tasks = None
@@ -245,6 +253,11 @@ class Switch:
         self._arbitrator = Arbitrator(
             opts.initial_election_id, opts.role_name, opts.role_config
         )
+
+    @property
+    def stash(self) -> dict[str, Any]:
+        "Switch stash, may be used to store per-switch data for any purpose."
+        return self._stash
 
     @property
     def device_id(self) -> int:

--- a/finsy/switch.py
+++ b/finsy/switch.py
@@ -183,6 +183,7 @@ class Switch:
     _address: str
     _options: SwitchOptions
     _stash: dict[str, Any]
+    _ee: "SwitchEmitter"
     _p4client: P4Client | None
     _p4schema: P4Schema
     _tasks: "SwitchTasks | None"
@@ -198,9 +199,6 @@ class Switch:
     control_task: asyncio.Task[Any] | None = None
     "Used by Controller to track switch's main task."
 
-    ee: "SwitchEmitter"
-    "Event emitter."
-
     def __init__(
         self,
         name: str,
@@ -214,6 +212,7 @@ class Switch:
         self._address = address
         self._options = options
         self._stash = {}
+        self._ee = SwitchEmitter(self)
         self._p4client = None
         self._p4schema = P4Schema(options.p4info, options.p4blob)
         self._tasks = None
@@ -225,7 +224,6 @@ class Switch:
         )
         self._gnmi_client = None
         self._ports = SwitchPortList()
-        self.ee = SwitchEmitter(self)
 
     @property
     def name(self) -> str:
@@ -258,6 +256,11 @@ class Switch:
     def stash(self) -> dict[str, Any]:
         "Switch stash, may be used to store per-switch data for any purpose."
         return self._stash
+
+    @property
+    def ee(self) -> "SwitchEmitter":
+        "Switch event emitter. See `SwitchEvent` for more details on events."
+        return self._ee
 
     @property
     def device_id(self) -> int:

--- a/finsy/switch.py
+++ b/finsy/switch.py
@@ -195,9 +195,7 @@ class Switch:
     _ports: SwitchPortList
     _is_channel_up: bool = False
     _api_version: ApiVersion = ApiVersion(1, 0, 0, "")
-
-    control_task: asyncio.Task[Any] | None = None
-    "Used by Controller to track switch's main task."
+    _control_task: asyncio.Task[Any] | None = None
 
     def __init__(
         self,


### PR DESCRIPTION
- Replace the `manager` property with `stash` and make it a `dict[str, Any]`.
- Make `control_task` a private attribute.
- Make `Switch.ee` read-only.